### PR TITLE
修复 ServerLinkHolder 无法重连的问题

### DIFF
--- a/ConnectX.Client/ServerLinkHolder.cs
+++ b/ConnectX.Client/ServerLinkHolder.cs
@@ -31,7 +31,6 @@ public class ServerLinkHolder : BackgroundService, IServerLinkHolder
         _tcpConnector = tcpConnector;
         _logger = logger;
 
-        _dispatcher.AddHandler<SigninSucceeded>(OnSigninSucceededReceived);
         _dispatcher.AddHandler<HeartBeat>(OnHeartBeatReceived);
         _dispatcher.AddHandler<ShutdownMessage>(OnShutdownMessageReceived);
     }
@@ -101,37 +100,46 @@ public class ServerLinkHolder : BackgroundService, IServerLinkHolder
 
     public async Task ConnectAsync(CancellationToken cancellationToken)
     {
+        _dispatcher.AddHandler<SigninSucceeded>(OnSigninSucceededReceived);
+
         _logger.LogConnectingToServer();
 
-        var endPoint = new IPEndPoint(_settingProvider.ServerAddress, _settingProvider.ServerPort);
-        var session = await _tcpConnector.ConnectAsync(endPoint, cancellationToken);
-
-        if (session == null)
+        try
         {
-            _logger.LogFailedToConnectToServer(endPoint);
-            return;
+            var endPoint = new IPEndPoint(_settingProvider.ServerAddress, _settingProvider.ServerPort);
+            var session = await _tcpConnector.ConnectAsync(endPoint, cancellationToken);
+
+            if (session == null)
+            {
+                _logger.LogFailedToConnectToServer(endPoint);
+                return;
+            }
+
+            session.BindTo(_dispatcher);
+            session.StartAsync(cancellationToken).Forget();
+
+            _logger.LogSendingSigninMessageToServer();
+
+            await Task.Delay(1000, cancellationToken);
+            await _dispatcher.SendAsync(session, new SigninMessage
+            {
+                JoinP2PNetwork = _settingProvider.JoinP2PNetwork,
+                DisplayName = session.RemoteEndPoint?.ToString() ?? Guid.NewGuid().ToString("N")
+            }, cancellationToken);
+
+            await TaskHelper.WaitUntilAsync(() => IsSignedIn, cancellationToken);
+
+            _logger.LogConnectedAndSignedToServer(endPoint);
+
+            ServerSession = session;
+            IsConnected = true;
+
+            Hive.Common.Shared.Helpers.TaskHelper.FireAndForget(() => CheckServerLivenessAsync(cancellationToken));
         }
-
-        session.BindTo(_dispatcher);
-        session.StartAsync(cancellationToken).Forget();
-
-        _logger.LogSendingSigninMessageToServer();
-
-        await Task.Delay(1000, cancellationToken);
-        await _dispatcher.SendAsync(session, new SigninMessage
+        finally
         {
-            JoinP2PNetwork = _settingProvider.JoinP2PNetwork,
-            DisplayName = session.RemoteEndPoint?.ToString() ?? Guid.NewGuid().ToString("N")
-        }, cancellationToken);
-
-        await TaskHelper.WaitUntilAsync(() => IsSignedIn, cancellationToken);
-
-        _logger.LogConnectedAndSignedToServer(endPoint);
-
-        ServerSession = session;
-        IsConnected = true;
-
-        Hive.Common.Shared.Helpers.TaskHelper.FireAndForget(() => CheckServerLivenessAsync(cancellationToken));
+            _dispatcher.RemoveHandler<SigninSucceeded>(OnSigninSucceededReceived);
+        }
     }
 
     public async Task DisconnectAsync(CancellationToken cancellationToken)
@@ -155,8 +163,6 @@ public class ServerLinkHolder : BackgroundService, IServerLinkHolder
         UserId = obj.Message.UserId;
 
         _logger.LogSuccessfullyLoggedIn(UserId);
-
-        _dispatcher.RemoveHandler<SigninSucceeded>(OnSigninSucceededReceived);
     }
 
     private void OnHeartBeatReceived(MessageContext<HeartBeat> ctx)


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on improving the connection handling in the `ConnectX.Client/ServerLinkHolder.cs` file by refining the connection process, adding error handling, and managing event handlers more effectively.

### Detailed summary
- Moved the addition of the `SigninSucceeded` handler to the `ConnectAsync` method.
- Wrapped the connection logic in a `try` block for better error handling.
- Added a `finally` block to remove the `SigninSucceeded` handler after connection attempts.
- Maintained logging for connection status and sign-in messages.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->