### PR TITLE
修复客户端无法收到踢人消息的问题

### DIFF
--- a/ConnectX.Client/Client.cs
+++ b/ConnectX.Client/Client.cs
@@ -104,9 +104,18 @@ public class Client
         var state = ctx.Message.State;
         var userInfo = ctx.Message.UserInfo;
 
-        if (state == GroupUserStates.Dismissed)
+        switch (state)
         {
-            ResetRoomState().Forget();
+            case GroupUserStates.Left:
+            case GroupUserStates.Disconnected:
+            case GroupUserStates.Kicked:
+                if (userInfo?.UserId == _serverLinkHolder.UserId)
+                    ResetRoomState().Forget();
+                else _roomInfoManager.AcquireGroupInfoAsync(_roomInfoManager.CurrentGroupInfo!.RoomId).Forget();
+                break;
+            case GroupUserStates.Dismissed:
+                ResetRoomState().Forget();
+                break;
         }
 
         OnGroupStateChanged?.Invoke(state, userInfo);

--- a/ConnectX.Client/ServerLinkHolder.cs
+++ b/ConnectX.Client/ServerLinkHolder.cs
@@ -124,7 +124,7 @@ public class ServerLinkHolder : BackgroundService, IServerLinkHolder
             await _dispatcher.SendAsync(session, new SigninMessage
             {
                 JoinP2PNetwork = _settingProvider.JoinP2PNetwork,
-                DisplayName = session.RemoteEndPoint?.ToString() ?? Guid.CreateVersion7().ToString("N")
+                DisplayName = $"User-{Guid.CreateVersion7().ToString("N")[^6..]}"
             }, cancellationToken);
 
             await TaskHelper.WaitUntilAsync(() => IsSignedIn, cancellationToken);

--- a/ConnectX.Server/Managers/GroupManager.cs
+++ b/ConnectX.Server/Managers/GroupManager.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using ConnectX.Server.Interfaces;
@@ -508,6 +509,9 @@ public class GroupManager
         if (user == null) return;
 
         group.Users.Remove(user);
+
+        if (state == GroupUserStates.Kicked) // 通知被踢客户端
+            _dispatcher.SendAsync(user.Session, new GroupUserStateChanged(state, user)).Forget();
 
         DeleteGroupNetworkMemberAsync(group, user).Forget();
         NotifyGroupMembersAsync(group, new GroupUserStateChanged(state, user)).Forget();


### PR DESCRIPTION
修复客户端无法收到踢人消息的问题
修复客户端初始显示名称为服务器地址的问题
为 ConsoleClient 添加了 kick 命令

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the user management features in a group chat system by adding user kick functionality, improving user state handling, and refining display name formatting.

### Detailed summary
- Updated `DisplayName` formatting in `ServerLinkHolder`.
- Added user kick notification in `GroupManager`.
- Enhanced user state handling in `Client` with a switch statement.
- Introduced `Kick` command in `ConsoleService` for kicking users.
- Implemented `HandleRoomKickAsync` method to process user kicks.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->