### PR TITLE
可选使用 UseSqlite

### DIFF
--- a/ConnectX.Server/ConnectX.Server.csproj
+++ b/ConnectX.Server/ConnectX.Server.csproj
@@ -23,6 +23,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.4" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.4" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.4" />

--- a/ConnectX.Server/Program.cs
+++ b/ConnectX.Server/Program.cs
@@ -24,9 +24,13 @@ internal static class Program
         {
             var configuration = ctx.Configuration;
             var connectionString = configuration.GetConnectionString("Default");
+            var useSqlite = bool.Parse(configuration["Server:UseSqlite"] ?? "false");
 
             services.AddDbContext<RoomOpsHistoryContext>(o =>
-                o.UseSqlServer(connectionString, b => b.MigrationsAssembly("ConnectX.Server")));
+            {
+                if (useSqlite) o.UseSqlite(connectionString, b => b.MigrationsAssembly("ConnectX.Server"));
+                else o.UseSqlServer(connectionString, b => b.MigrationsAssembly("ConnectX.Server"));
+            });
 
             services.AddHttpClient<IZeroTierApiService, ZeroTierApiService>(client =>
             {

--- a/ConnectX.Server/appsettings.json
+++ b/ConnectX.Server/appsettings.json
@@ -42,6 +42,7 @@
     "ListenPort": 3535,
     "ListenAddress": "127.0.0.1",
     "ServerId": "ddad03b9-d122-421d-add7-1d09e65b4295"
+    "UseSqlite": false
   },
   "ZeroTier": {
     "EndPoint": "http://127.0.0.1:3339",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces the option to use SQLite as a database provider in the `ConnectX.Server` application, allowing for more flexible database management.

### Detailed summary
- In `appsettings.json`, added `"UseSqlite": false` to configuration.
- In `ConnectX.Server.csproj`, added a package reference for `Microsoft.EntityFrameworkCore.Sqlite`.
- In `Program.cs`, implemented logic to choose between SQLite and SQL Server based on the configuration value.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->