### PR TITLE
Fix retry without interval

### DIFF
--- a/ConnectX.Server/InterconnectServerLinkHolder.cs
+++ b/ConnectX.Server/InterconnectServerLinkHolder.cs
@@ -125,6 +125,9 @@ public class InterconnectServerLinkHolder : BackgroundService
                 {
                     _logger.LogFailedToConnectToRemoteServer(endPoint);
                     _pendingEstablishInterconnectServerLinks.Enqueue(endPoint);
+
+                    await Task.Delay(5000, stoppingToken);
+
                     continue;
                 }
 

--- a/ConnectX.Server/JsonConverters/IPEndPointJsonConverter.cs
+++ b/ConnectX.Server/JsonConverters/IPEndPointJsonConverter.cs
@@ -13,18 +13,9 @@ public class IPEndPointJsonConverter : JsonConverter<IPEndPoint>
             return null;
 
         // Try parse IP:Port format
-        var parts = endpointString.Split(':');
-        if (parts.Length < 2)
-            throw new JsonException($"Invalid IPEndPoint format: {endpointString}");
-
-        if (!int.TryParse(parts[^1], out var port))
-            throw new JsonException($"Invalid port number: {parts[^1]}");
-
-        var ipPart = string.Join(":", parts[..^1]);
-        if (!IPAddress.TryParse(ipPart, out var ip))
-            throw new JsonException($"Invalid IP address: {ipPart}");
-
-        return new IPEndPoint(ip, port);
+        if (IPEndPoint.TryParse(endpointString, out var endpoint))
+            return endpoint;
+        else throw new JsonException($"Invalid IPEndPoint format: {endpointString}");
     }
 
     public override void Write(Utf8JsonWriter writer, IPEndPoint value, JsonSerializerOptions options)


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on improving error handling and simplifying the parsing of `IPEndPoint` strings in the `ConnectX.Server` project.

### Detailed summary
- In `ConnectX.Server/InterconnectServerLinkHolder.cs`, a delay of 5000 milliseconds is added before continuing the loop after a failed connection attempt.
- In `ConnectX.Server/JsonConverters/IPEndPointJsonConverter.cs`, the parsing logic for `IPEndPoint` is simplified by using `IPEndPoint.TryParse`, removing multiple lines of error handling code.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->